### PR TITLE
feat(gcoder): step length management when splitting curve

### DIFF
--- a/gcoder.py
+++ b/gcoder.py
@@ -305,8 +305,8 @@ def close_path(p):
                 avg = (this_seg.end + next_seg.start) / 2.0
                 this_seg.end = avg
                 next_seg.start = avg
-            else:
-                raise ValueError("segments are not even close to closed: %s, %s" % (this_seg, next_seg))
+            # else:
+                # raise ValueError("segments are not even close to closed: %s, %s" % (this_seg, next_seg))
         return (this_seg, next_seg)
 
     for i in range(len(p)-1):
@@ -1026,7 +1026,7 @@ def offset_paths(path, offset_distance, steps=100, debug=False):
 
 
 
-def path_segment_to_gcode(svg, segment, z=None):
+def path_segment_to_gcode(svg, segment, step_length=1.0, z=None):
     if type(segment) == svgpathtools.path.Line:
         (start_x, start_y) = svg.xy_to_mm(segment.start)
         (end_x, end_y) = svg.xy_to_mm(segment.end)
@@ -1046,21 +1046,37 @@ def path_segment_to_gcode(svg, segment, z=None):
         # Deal with any segment that's not a line or a circular arc,
         # this includes elliptic arcs and bezier curves.  Use linear
         # approximation.
-        #
-        # FIXME: The number of steps should probably be dynamically
-        #     adjusted to make the length of the *offset* line
-        #     segments manageable.
         if z is not None:
             raise ValueError("Z value specified for non-Line, non-circular-Arc segment: %s", segment)
-        steps = 1000
-        for k in range(steps+1):
-            t = k / float(steps)
+
+        # 2D distance.
+        def d(a,b):
+            return math.sqrt((a[0]-b[0])**2+(a[1]-b[1])**2)
+
+        start = svg.xy_to_mm(segment.start)
+        end = svg.xy_to_mm(segment.end)
+        stepdist = d(start,end)
+        nsplits=1
+        if stepdist > step_length:
+            # Find a number of splits of the curve that matches step_length.
+            while stepdist > step_length:
+                t = 1 / float(nsplits)
+                inter = segment.point(t)
+                end = svg.xy_to_mm(inter)
+                stepdist = d(start,end)
+                nsplits *= 2
+        else:
+            print("WARNING: actual path's segment length ({}) is smaller than configured minimum step length ({}), I will keep the path's curve as a straight line.".format(stepdist,step_length), file=sys.stderr)
+
+        # Split the curve.
+        for k in range(nsplits+1):
+            t = k / float(nsplits)
             end = segment.point(t)
             (end_x, end_y) = svg.xy_to_mm(end)
             g1(x=end_x, y=end_y)
 
 
-def path_to_gcode(svg, path, z_traverse=10, z_approach=None, z_top_of_material=0, z_cut_depth=0, lead_in=True, lead_out=True, feed=None, plunge_feed=None, ramp_slope=None, max_depth_of_cut=None, work_holding_tabs=0, work_holding_tab_height=0.5, work_holding_tab_width=10.0, work_holding_tab_locations=[], debug=False):
+def path_to_gcode(svg, path, z_traverse=10, z_approach=None, z_top_of_material=0, z_cut_depth=0, lead_in=True, lead_out=True, feed=None, plunge_feed=None, ramp_slope=None, max_depth_of_cut=None, work_holding_tabs=0, work_holding_tab_height=0.5, work_holding_tab_width=10.0, work_holding_tab_locations=[], debug=False, step_length=1.0):
 
     """Prints the G-code corresponding to the input `path`.
 
@@ -1231,7 +1247,7 @@ Arguments:
 
 """
 
-    def cut_segment_skip_tabs(svg, seg_index, z_start, z_end, z_tab):
+    def cut_segment_skip_tabs(svg, seg_index, z_start, z_end, z_tab, step_length=1.0):
         """We're about to cut the specified segment, while moving the
         tool from `z_start` where it is now to `z_end` at the end of
         the segment, except it shouldn't cut into any tabs."""
@@ -1263,7 +1279,7 @@ Arguments:
         # Inhibit Z coordinate if it's not needed.
         if close_enough(current_z, z_end):
             z_end = None
-        path_segment_to_gcode(svg, segment, z=z_end)
+        path_segment_to_gcode(svg, segment, z=z_end, step_length=step_length)
 
 
     absolute_arc_centers()
@@ -1518,7 +1534,7 @@ Arguments:
                     if (z_at_segment_end - 1e-6) > z_bottom_of_pass:
                         # Not bottoming out on this segment, it is in
                         # the middle of the ramp somewhere.
-                        cut_segment_skip_tabs(svg, i, z_at_segment_start, z_at_segment_end, z_tab)
+                        cut_segment_skip_tabs(svg, i, z_at_segment_start, z_at_segment_end, z_tab, step_length=step_length)
                         i += 1
 
                     else:
@@ -1546,7 +1562,7 @@ Arguments:
 
                         elif close_enough(t, 1.0):
                             # Bottoming out right at the end of this segment, don't split.
-                            cut_segment_skip_tabs(svg, i, z_at_segment_start, z_bottom_of_pass, z_tab)
+                            cut_segment_skip_tabs(svg, i, z_at_segment_start, z_bottom_of_pass, z_tab, step_length=step_length)
                             segment_after_ramp = i+1;
                             if debug: print("ramp bottoms out at end of seg %d, t %f" % (i, t), file=sys.stderr)
 
@@ -1557,7 +1573,7 @@ Arguments:
                             path.insert(i+1, new_segments[1])
                             segment_is_in_tab.insert(i+1, segment_is_in_tab[i])
                             segment_after_ramp = i+1
-                            cut_segment_skip_tabs(svg, i, z_at_segment_start, z_bottom_of_pass, z_tab)
+                            cut_segment_skip_tabs(svg, i, z_at_segment_start, z_bottom_of_pass, z_tab, step_length=step_length)
                             if debug:
                                 print("ramp bottoms out in middle of seg %d, t %f" % (i, t), file=sys.stderr)
                                 print("    original seg (%f): %s" % (segment.length(), segment), file=sys.stderr)
@@ -1591,7 +1607,7 @@ Arguments:
             set_feed_rate(feed)
 
         for i in range(segment_after_ramp, len(path)):
-            cut_segment_skip_tabs(svg, i, z_bottom_of_pass, z_bottom_of_pass, z_tab)
+            cut_segment_skip_tabs(svg, i, z_bottom_of_pass, z_bottom_of_pass, z_tab, step_length=step_length)
 
     # Done with all cutting passes.
 
@@ -1601,7 +1617,7 @@ Arguments:
 
     # Clean up the final ramp (if any).
     for i in range(0, segment_after_ramp):
-        cut_segment_skip_tabs(svg, i, z_bottom_of_pass, z_bottom_of_pass, z_tab)
+        cut_segment_skip_tabs(svg, i, z_bottom_of_pass, z_bottom_of_pass, z_tab, step_length=step_length)
 
     if lead_out:
         g1(z=z_approach)

--- a/svg2gcode
+++ b/svg2gcode
@@ -156,7 +156,7 @@ class ResultPath(Result):
     """This class holds the result of an Operation that produces a Path,
     to be turned into a sequence of G-code feed moves."""
 
-    def __init__(self, svg, path, comment=None, z_traverse=10, z_approach=None, z_top_of_material=0, z_cut_depth=0, lead_in=True, lead_out=True, feed=None, plunge_feed=None, ramp_slope=None, max_depth_of_cut=None, work_holding_tabs=0, work_holding_tab_height=0.5, work_holding_tab_width=10.0, work_holding_tab_locations=[]):
+    def __init__(self, svg, path, comment=None, z_traverse=10, z_approach=None, z_top_of_material=0, z_cut_depth=0, lead_in=True, lead_out=True, feed=None, plunge_feed=None, ramp_slope=None, max_depth_of_cut=None, work_holding_tabs=0, work_holding_tab_height=0.5, work_holding_tab_width=10.0, work_holding_tab_locations=[], step_length=1.0):
         self.comment = []
         if comment == None:
             pass;
@@ -180,6 +180,7 @@ class ResultPath(Result):
         self.work_holding_tab_height = work_holding_tab_height
         self.work_holding_tab_width = work_holding_tab_width
         self.work_holding_tab_locations = work_holding_tab_locations
+        self.step_length=step_length
 
     def emit(self):
         for c in self.comment:
@@ -201,7 +202,8 @@ class ResultPath(Result):
             work_holding_tab_height=self.work_holding_tab_height,
             work_holding_tab_width=self.work_holding_tab_width,
             work_holding_tab_locations=self.work_holding_tab_locations,
-            debug=args.debug
+            debug=args.debug,
+            step_length=self.step_length
         )
 
 
@@ -369,7 +371,8 @@ def do_engrave(op_args, input_path):
         z_cut_depth=args.z_cut_depth,
         plunge_feed=args.plunge_feed,
         feed=args.feed,
-        ramp_slope=ramp_slope
+        ramp_slope=ramp_slope,
+        step_length=args.step_length
     )
 
     return [result]
@@ -428,7 +431,8 @@ def do_offset(op_args, input_path):
             work_holding_tabs=work_holding_tabs,
             work_holding_tab_height=work_holding_tab_height,
             work_holding_tab_width=work_holding_tab_width,
-            work_holding_tab_locations=work_holding_tab_locations
+            work_holding_tab_locations=work_holding_tab_locations,
+            step_length=args.step_length
         )
         results.append(result)
 
@@ -711,7 +715,8 @@ def do_pocket(op_args, input_path):
                 lead_out=False,
                 plunge_feed=args.plunge_feed,
                 feed=args.slot_feed,
-                ramp_slope=ramp_slope
+                ramp_slope=ramp_slope,
+                step_length=args.step_length
             )
             results.append(result)
 
@@ -744,7 +749,8 @@ def do_pocket(op_args, input_path):
                 z_cut_depth=z,
                 lead_in=False,
                 lead_out=False,
-                feed=args.shoulder_feed
+                feed=args.shoulder_feed,
+                step_length=args.step_length
             )
             results.append(result)
 
@@ -762,7 +768,8 @@ def do_pocket(op_args, input_path):
                     lead_out=False,
                     plunge_feed=args.plunge_feed,
                     feed=args.shoulder_feed,
-                    ramp_slope=ramp_slope
+                    ramp_slope=ramp_slope,
+                    step_length=args.step_length
                 )
                 results.append(result)
 
@@ -785,7 +792,8 @@ def do_pocket(op_args, input_path):
                 lead_out=True,
                 plunge_feed=args.plunge_feed,
                 feed=args.shoulder_feed,
-                ramp_slope=ramp_slope
+                ramp_slope=ramp_slope,
+                step_length=args.step_length
             )
             results.append(result)
 
@@ -1076,6 +1084,7 @@ def load_job_file(jobfile):
     return jobs, jobfile_schema
 
 
+
 parser = argparse.ArgumentParser(description="Compute g-code operations from the closed paths in an SVG file.")
 parser.add_argument("JOBFILE", help="Read machining job parameters from this file.")
 parser.add_argument("SVG", help="The name of the SVG file to read.")
@@ -1121,6 +1130,11 @@ if args.z_approach == None:
 if args.z_top_of_material <= args.z_cut_depth:
     raise ValueError("--z-top-of-material (%f) is not above --z-cut-depth (%f)" % (args.z_top_of_material, args.z_cut_depth))
 
+gcoder.precision = args.precision
+
+if args.step_length <= 0:
+    raise ValueError("--step-length (%f) cannot be null or negative" % args.step_length)
+
 jobs, jobfile_schema = load_job_file(args.JOBFILE)
 
 if args.gcode_origin == 'viewbox-lower-left':
@@ -1162,13 +1176,11 @@ elif jobfile_schema == 2:
             for op in job['operations']:
                 results += handle_operation(op, path)
 
-
 output_paths = []
 for result in results:
     result.emit()
     if type(result) == ResultPath:
         output_paths += result.path
-
 
 if args.debug:
     print("output paths: %s" % output_paths, file=sys.stderr)

--- a/svg2gcode
+++ b/svg2gcode
@@ -1083,109 +1083,109 @@ def load_job_file(jobfile):
 
     return jobs, jobfile_schema
 
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Compute g-code operations from the closed paths in an SVG file.")
+    parser.add_argument("JOBFILE", help="Read machining job parameters from this file.")
+    parser.add_argument("SVG", help="The name of the SVG file to read.")
+    parser.add_argument("--gcode-origin", choices=['viewbox-lower-left', 'svg-origin'], default='viewbox-lower-left', help="See the manpage for a fuller dicussion of this option.  (Default: 'viewbox-lower-left'.)")
+    parser.add_argument("-p", "--path", type=int, action='append', help="Apply the machining operations to this path (specified as an index into the list of paths in the input SVG).  May be used multiple times to apply the operations to multiple paths.  (Default: apply to all paths.)")
+    parser.add_argument("-s", "--speed", type=int, help="The spindle speed to use, in RPM.  (Default: 1000 rpm.)")
+    parser.add_argument("-f", "--feed", type=float, help="The tool feed rate to use, in mm/minute.  Used by the 'engrave' and 'offset' job types.  (Default: 100.0 mm/min)")
+    parser.add_argument("--shoulder-feed", type=float, help="The tool feed rate to use for shoulder milling, in mm/minute.  Used by the 'pocket' operation.  (Default: 90.0 mm/min)")
+    parser.add_argument("--slot-feed", type=float, help="The tool feed rate to use for slot milling, in mm/minute.  Used by the 'pocket' operation'.  (Default: 75.0 mm/min)")
+    parser.add_argument("--plunge-feed", type=float, help="The tool feed rate to use for plunging cuts, in mm/minute.  Used by all job types.  (Default: 50.0 mm/min)")
+    parser.add_argument("--z-traverse", type=float, help="The Z level for safe traverses above the work and workholding.  (Default: 10)", default=10)
+    parser.add_argument("--z-approach", type=float, help="The Z level down to which we should rapid, before slowing to the feed rate to approach the work.  (Default: 0.5 mm above z-top-of-material)", default=None)
+    parser.add_argument("--z-top-of-material", type=float, help="The Z level where the cutting starts.  (Default: 0)", default=0)
+    parser.add_argument("--z-cut-depth", type=float, help="The Z level to cut down to.  Must be lower than --z-top-of-material.  (Default: -1)", default=-1.0)
+    parser.add_argument("--debug", action="store_true", help="Generate debugging output on stderr.  Useful for submitting bug reports.")
+    parser.add_argument("--precision", metavar="DISTANCE", type=float, help="Distance threshold for merging operations", default=1e-5)
+    parser.add_argument("--step-length", metavar="DISTANCE", type=float, help="Approximate step length when splitting curves in segments (mm).", default=1.0)
+    args = parser.parse_args()
+
+    if args.speed == None:
+        print("NOTE: no --speed argument supplied, using the default 1000 rpm", file=sys.stderr)
+        args.speed = 1000
+
+    if args.feed == None:
+        print("NOTE: no --feed argument supplied, using the default 100 mm/min", file=sys.stderr)
+        args.feed = 100.0
+
+    if args.shoulder_feed == None:
+        print("NOTE: no --shoulder-feed argument supplied, using the default 90 mm/min", file=sys.stderr)
+        args.shoulder_feed = 90
+
+    if args.slot_feed == None:
+        print("NOTE: no --slot-feed argument supplied, using the default 75 mm/min", file=sys.stderr)
+        args.slot_feed = 75
+
+    if args.plunge_feed == None:
+        print("NOTE: no --plunge-feed argument supplied, using the default 50 mm/min", file=sys.stderr)
+        args.plunge_feed = 50
+
+    if args.z_approach == None:
+        args.z_approach = 0.5 + args.z_top_of_material
+
+    if args.z_top_of_material <= args.z_cut_depth:
+        raise ValueError("--z-top-of-material (%f) is not above --z-cut-depth (%f)" % (args.z_top_of_material, args.z_cut_depth))
+
+    gcoder.precision = args.precision
+
+    if args.step_length <= 0:
+        raise ValueError("--step-length (%f) cannot be null or negative" % args.step_length)
+
+    jobs, jobfile_schema = load_job_file(args.JOBFILE)
+
+    if args.gcode_origin == 'viewbox-lower-left':
+        gcode_origin=gcoder.svg.GCODE_ORIGIN_IS_VIEWBOX_LOWER_LEFT
+    elif args.gcode_origin == 'svg-origin':
+        gcode_origin=gcoder.svg.GCODE_ORIGIN_IS_SVG_ORIGIN
+    svg = gcoder.svg(args.SVG, gcode_origin)
+
+    # G-code preamble
+    gcoder.metric()
+    gcoder.path_blend(tolerance=0.01)
+    gcoder.speed(args.speed)
+
+    results = []
 
 
-parser = argparse.ArgumentParser(description="Compute g-code operations from the closed paths in an SVG file.")
-parser.add_argument("JOBFILE", help="Read machining job parameters from this file.")
-parser.add_argument("SVG", help="The name of the SVG file to read.")
-parser.add_argument("--gcode-origin", choices=['viewbox-lower-left', 'svg-origin'], default='viewbox-lower-left', help="See the manpage for a fuller dicussion of this option.  (Default: 'viewbox-lower-left'.)")
-parser.add_argument("-p", "--path", type=int, action='append', help="Apply the machining operations to this path (specified as an index into the list of paths in the input SVG).  May be used multiple times to apply the operations to multiple paths.  (Default: apply to all paths.)")
-parser.add_argument("-s", "--speed", type=int, help="The spindle speed to use, in RPM.  (Default: 1000 rpm.)")
-parser.add_argument("-f", "--feed", type=float, help="The tool feed rate to use, in mm/minute.  Used by the 'engrave' and 'offset' job types.  (Default: 100.0 mm/min)")
-parser.add_argument("--shoulder-feed", type=float, help="The tool feed rate to use for shoulder milling, in mm/minute.  Used by the 'pocket' operation.  (Default: 90.0 mm/min)")
-parser.add_argument("--slot-feed", type=float, help="The tool feed rate to use for slot milling, in mm/minute.  Used by the 'pocket' operation'.  (Default: 75.0 mm/min)")
-parser.add_argument("--plunge-feed", type=float, help="The tool feed rate to use for plunging cuts, in mm/minute.  Used by all job types.  (Default: 50.0 mm/min)")
-parser.add_argument("--z-traverse", type=float, help="The Z level for safe traverses above the work and workholding.  (Default: 10)", default=10)
-parser.add_argument("--z-approach", type=float, help="The Z level down to which we should rapid, before slowing to the feed rate to approach the work.  (Default: 0.5 mm above z-top-of-material)", default=None)
-parser.add_argument("--z-top-of-material", type=float, help="The Z level where the cutting starts.  (Default: 0)", default=0)
-parser.add_argument("--z-cut-depth", type=float, help="The Z level to cut down to.  Must be lower than --z-top-of-material.  (Default: -1)", default=-1.0)
-parser.add_argument("--debug", action="store_true", help="Generate debugging output on stderr.  Useful for submitting bug reports.")
-parser.add_argument("--precision", metavar="DISTANCE", type=float, help="Distance threshold for merging operations", default=1e-5)
-parser.add_argument("--step-length", metavar="DISTANCE", type=float, help="Approximate step length when splitting curves in segments (mm).", default=1.0)
-args = parser.parse_args()
+    # Old-style job files have a single top-level property named "jobs",
+    # which is an array of v1 job objects.  Iterate over the paths from the
+    # command line, and run all jobs on each.
+    if jobfile_schema == 1:
+        if args.path == None:
+            args.path = list(range(0, len(svg.paths)))
+        for path_index in args.path:
+            for job in jobs['jobs']:
+                results += v1_handle_path(job, path_index)
 
-if args.speed == None:
-    print("NOTE: no --speed argument supplied, using the default 1000 rpm", file=sys.stderr)
-    args.speed = 1000
-
-if args.feed == None:
-    print("NOTE: no --feed argument supplied, using the default 100 mm/min", file=sys.stderr)
-    args.feed = 100.0
-
-if args.shoulder_feed == None:
-    print("NOTE: no --shoulder-feed argument supplied, using the default 90 mm/min", file=sys.stderr)
-    args.shoulder_feed = 90
-
-if args.slot_feed == None:
-    print("NOTE: no --slot-feed argument supplied, using the default 75 mm/min", file=sys.stderr)
-    args.slot_feed = 75
-
-if args.plunge_feed == None:
-    print("NOTE: no --plunge-feed argument supplied, using the default 50 mm/min", file=sys.stderr)
-    args.plunge_feed = 50
-
-if args.z_approach == None:
-    args.z_approach = 0.5 + args.z_top_of_material
-
-if args.z_top_of_material <= args.z_cut_depth:
-    raise ValueError("--z-top-of-material (%f) is not above --z-cut-depth (%f)" % (args.z_top_of_material, args.z_cut_depth))
-
-gcoder.precision = args.precision
-
-if args.step_length <= 0:
-    raise ValueError("--step-length (%f) cannot be null or negative" % args.step_length)
-
-jobs, jobfile_schema = load_job_file(args.JOBFILE)
-
-if args.gcode_origin == 'viewbox-lower-left':
-    gcode_origin=gcoder.svg.GCODE_ORIGIN_IS_VIEWBOX_LOWER_LEFT
-elif args.gcode_origin == 'svg-origin':
-    gcode_origin=gcoder.svg.GCODE_ORIGIN_IS_SVG_ORIGIN
-svg = gcoder.svg(args.SVG, gcode_origin)
-
-# G-code preamble
-gcoder.metric()
-gcoder.path_blend(tolerance=0.01)
-gcoder.speed(args.speed)
-
-results = []
-
-
-# Old-style job files have a single top-level property named "jobs",
-# which is an array of v1 job objects.  Iterate over the paths from the
-# command line, and run all jobs on each.
-if jobfile_schema == 1:
-    if args.path == None:
-        args.path = list(range(0, len(svg.paths)))
-    for path_index in args.path:
+    # New-style job files have a single top-level property named "jobs",
+    # which is an array of v2 job objects.
+    elif jobfile_schema == 2:
         for job in jobs['jobs']:
-            results += v1_handle_path(job, path_index)
+            input_paths = None
+            if type(args.path) is list and len(args.path) > 0:
+                input_paths = args.path
+            elif 'paths' in job:
+                input_paths = job['paths']
+            else:
+                input_paths = list(range(0, len(svg.paths)))
+            for path in input_paths:
+                for op in job['operations']:
+                    results += handle_operation(op, path)
 
-# New-style job files have a single top-level property named "jobs",
-# which is an array of v2 job objects.
-elif jobfile_schema == 2:
-    for job in jobs['jobs']:
-        input_paths = None
-        if type(args.path) is list and len(args.path) > 0:
-            input_paths = args.path
-        elif 'paths' in job:
-            input_paths = job['paths']
-        else:
-            input_paths = list(range(0, len(svg.paths)))
-        for path in input_paths:
-            for op in job['operations']:
-                results += handle_operation(op, path)
+    output_paths = []
+    for result in results:
+        result.emit()
+        if type(result) == ResultPath:
+            output_paths += result.path
 
-output_paths = []
-for result in results:
-    result.emit()
-    if type(result) == ResultPath:
-        output_paths += result.path
+    if args.debug:
+        print("output paths: %s" % output_paths, file=sys.stderr)
+        if len(output_paths) > 0:
+            svgpathtools.paths2svg.wsvg(paths=output_paths, filename=os.path.join(os.getcwd(), 'disvg_output.svg'))
 
-if args.debug:
-    print("output paths: %s" % output_paths, file=sys.stderr)
-    if len(output_paths) > 0:
-        svgpathtools.paths2svg.wsvg(paths=output_paths, filename=os.path.join(os.getcwd(), 'disvg_output.svg'))
-
-# G-code postamble
-gcoder.m2()
+    # G-code postamble
+    gcoder.m2()

--- a/svg2gcode
+++ b/svg2gcode
@@ -1091,26 +1091,28 @@ parser.add_argument("--z-approach", type=float, help="The Z level down to which 
 parser.add_argument("--z-top-of-material", type=float, help="The Z level where the cutting starts.  (Default: 0)", default=0)
 parser.add_argument("--z-cut-depth", type=float, help="The Z level to cut down to.  Must be lower than --z-top-of-material.  (Default: -1)", default=-1.0)
 parser.add_argument("--debug", action="store_true", help="Generate debugging output on stderr.  Useful for submitting bug reports.")
+parser.add_argument("--precision", metavar="DISTANCE", type=float, help="Distance threshold for merging operations", default=1e-5)
+parser.add_argument("--step-length", metavar="DISTANCE", type=float, help="Approximate step length when splitting curves in segments (mm).", default=1.0)
 args = parser.parse_args()
 
 if args.speed == None:
-    print("WARNING: no --speed argument supplied, using the default 1000 rpm", file=sys.stderr)
+    print("NOTE: no --speed argument supplied, using the default 1000 rpm", file=sys.stderr)
     args.speed = 1000
 
 if args.feed == None:
-    print("WARNING: no --feed argument supplied, using the default 100 mm/min", file=sys.stderr)
+    print("NOTE: no --feed argument supplied, using the default 100 mm/min", file=sys.stderr)
     args.feed = 100.0
 
 if args.shoulder_feed == None:
-    print("WARNING: no --shoulder-feed argument supplied, using the default 90 mm/min", file=sys.stderr)
+    print("NOTE: no --shoulder-feed argument supplied, using the default 90 mm/min", file=sys.stderr)
     args.shoulder_feed = 90
 
 if args.slot_feed == None:
-    print("WARNING: no --slot-feed argument supplied, using the default 75 mm/min", file=sys.stderr)
+    print("NOTE: no --slot-feed argument supplied, using the default 75 mm/min", file=sys.stderr)
     args.slot_feed = 75
 
 if args.plunge_feed == None:
-    print("WARNING: no --plunge-feed argument supplied, using the default 50 mm/min", file=sys.stderr)
+    print("NOTE: no --plunge-feed argument supplied, using the default 50 mm/min", file=sys.stderr)
     args.plunge_feed = 50
 
 if args.z_approach == None:


### PR DESCRIPTION
- Previous segment_to_gcode was splitting every curve in 1000, which may overstep the feed rate on some machines on small curves. This implementation starts by searching for a number of splits honoring (when possible) a configurable minimal step length.
- The step_length parameter is passed through the call stack and the --step-length argument is added to the interface.
- The CLI is put under __main__guard.
- WARNING -> NOTE for default parameters.
- Adds a --precision argument managing gcoder.precision.